### PR TITLE
Invalid operator for default value for named params

### DIFF
--- a/recipes/required-and-default-props.md
+++ b/recipes/required-and-default-props.md
@@ -31,7 +31,7 @@ import 'package:flutter/material.dart';
 class SomeComponent extends StatelessWidget {
   SomeComponent({
     @required this.foo,
-    this.bar = 'some string',
+    this.bar : 'some string',
   });
 
   final String foo;


### PR DESCRIPTION
You should use `:` operator instead `=` to declare default value for named parameters.

Example:

```dart
// Output: 'Hello, world!'
main() => say();
say({message : 'Hello, world!'}) => print(message);
```